### PR TITLE
BREAKING: Make the general library more thread-safe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrisbox"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]
@@ -9,3 +9,4 @@ serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
 tokio = { version = "1.40.0", features = ["rt-multi-thread", "sync", "macros"] }
 tokio-tungstenite = { version = "0.24.0", features = ["native-tls"] }
+tracing = "0.1.44"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use tokio_tungstenite::{connect_async, tungstenite::Message};
 pub mod models;
 pub mod packets;
 
+#[derive(Debug)]
 pub struct ChatboxEventLoop {
     rx: Receiver<packets::ServerPacket>,
 }


### PR DESCRIPTION
This PR separates the client into two parts: the receiver and the sender.
The sender can safely be sent around in an Arc<> and does not need a mutable reference.
The Receiver must have a mutable reference and cannot be shared.